### PR TITLE
[#27] Fix restoringCard background issue.

### DIFF
--- a/Sources/Wisp Managing/WispManager.swift
+++ b/Sources/Wisp Managing/WispManager.swift
@@ -120,7 +120,7 @@ private extension WispManager {
             targetCell.contentView.drawHierarchy(in: targetCell.contentView.bounds, afterScreenUpdates: true)
         }
         let imageView = UIImageView(image: cellRecentImage)
-        imageView.backgroundColor = targetCell.backgroundColor
+        imageView.backgroundColor = targetCell.backgroundConfiguration?.backgroundColor ?? targetCell.backgroundColor
         
         // restoring card snapshot 설정
         restoringCard.setupSnapshots(


### PR DESCRIPTION
Summary

This PR fixes an issue where the restoringCard did not reflect the UICollectionViewCell’s backgroundConfiguration, causing the restoring card’s background to appear unintentionally transparent.

Changes
- Ensures that the restoring card background now correctly matches the visual appearance of the source cell