### PR TITLE
[#35] Fix pan gesture overlap with MKMapView

### DIFF
--- a/Sources/Extensions/ScrollableComponent.swift
+++ b/Sources/Extensions/ScrollableComponent.swift
@@ -6,10 +6,17 @@
 //
 
 import UIKit
+import MapKit
 
 internal protocol ScrollableComponent: UIView { }
+
+// MARK: - UIControl
 
 extension UIDatePicker: ScrollableComponent { }
 extension UISegmentedControl: ScrollableComponent { }
 extension UISlider: ScrollableComponent { }
 extension UISwitch: ScrollableComponent { }
+
+// MARK: - MapKit
+
+extension MKMapView: ScrollableComponent { }

--- a/Sources/Transition/WispPresentationController.swift
+++ b/Sources/Transition/WispPresentationController.swift
@@ -180,10 +180,10 @@ extension WispPresentationController: UIGestureRecognizerDelegate {
             }
         }
         
-        /// blocks `wisp`'s `pan gesture` when tried to pan 'scrollable' `UIControls`.
-        let subControls: Set<UIControl> = findSubviews(in: view)
-        let scrollableSubControls = subControls.filter { $0 is (any ScrollableComponent) }
-        for control in scrollableSubControls {
+        /// blocks `wisp`'s `pan gesture` when tried to pan 'scrollable view components'.
+        let subviews: Set<UIView> = findSubviews(in: view)
+        let scrollableSubComponents = subviews.filter { $0 is (any ScrollableComponent) }
+        for control in scrollableSubComponents {
             if control.isDescendant(of: view){
                 let controlConvertedFrame = control.superview?.convert(control.frame, to: cardContainerView) ?? .zero
                 if controlConvertedFrame.contains(gesturePoint) {


### PR DESCRIPTION
This PR introduces improvements to how `Wisp` determines which views should prioritize scroll gestures over `Wisp`’s own pan gesture.

### Changes
- Renamed `ScrollableControl` protocol to `ScrollableComponent` for clearer semantics.
- Made `MKMapView` conform to `ScrollableComponent`, ensuring that its scroll gestures take precedence and preventing overlapping with Wisp gestures.