### PR TITLE
Handle Wisp dismiss when collectionView is off-screen

### DIFF
--- a/Sources/WispPresenter/WispPresenter.swift
+++ b/Sources/WispPresenter/WispPresenter.swift
@@ -169,6 +169,20 @@ internal extension WispPresenter {
             return
         }
         
+        guard context.collectionView?.window != nil else {
+            print("""
+                  ⚠️ Warning: collectionView.window is nil — unable to perform restore animation.
+                  Falling back to default dismiss transition.
+                  """)
+            context.collectionView?.makeSelectedCellVisible(indexPath: context.sourceIndexPath)
+            delegate?.wispWillRestore()
+            viewControllerToDismiss.dismiss(animated: true) { [weak self] in
+                guard let self else { return }
+                self.delegate?.wispDidRestore()
+            }
+            return
+        }
+        
         guard let transitioningDelegate else {
             context.collectionView?.makeSelectedCellVisible(indexPath: context.sourceIndexPath)
             viewControllerToDismiss.dismiss(animated: true)


### PR DESCRIPTION
Added exception handling for cases where the target collection view is no longer attached to a window during Wisp dismiss.
If collectionView.window is nil, the system now directly calls the dismiss method instead of attempting a restore animation.