### PR TITLE
[#63] Fix: Wisp Pan Gesture with Non-Editable UITextView

### DIFF
--- a/Sources/Transition/WispPresentationController.swift
+++ b/Sources/Transition/WispPresentationController.swift
@@ -190,10 +190,15 @@ extension WispPresentationController: UIGestureRecognizerDelegate {
         
         /// blocks `wisp`'s `pan gesture` when tried to pan `first responder`.
         if let firstResponder = findFirstResponder(in: view),
-            firstResponder.isDescendant(of: view),
-            let superview = firstResponder.superview {
+           firstResponder.isDescendant(of: view),
+           let superview = firstResponder.superview {
             let firstResponderConvertedFrame = superview.convert(firstResponder.frame, to: view)
+
             if firstResponderConvertedFrame.contains(gesturePoint) {
+                // If the first responder is a non-editable UITextView, allow the gesture.
+                if let textView = firstResponder as? UITextView, !textView.isEditable {
+                    return true
+                }
                 return false
             }
         }


### PR DESCRIPTION
This PR addresses an issue where Wisp's pan gesture for dismissal was blocked by non-editable UITextViews when they became first responder (e.g., during text selection).

The `gestureRecognizerShouldBegin` logic in `WispPresentationController.swift` has been updated to explicitly check if first responder UITextView is editable.